### PR TITLE
Alternative worker

### DIFF
--- a/Command/ConsumerCommand.php
+++ b/Command/ConsumerCommand.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Laelaps\GearmanBundle\Command;
+
+use Laelaps\GearmanBundle\Event\ConsumeEvents;
+use Laelaps\GearmanBundle\Worker\HandlerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ConsumerCommand extends Command
+{
+    const OPTION_MAX_MESSAGES = 'max-messages';
+    const OPTION_MAX_RUNTIME  = 'max-runtime';
+
+    /** @var \GearmanWorker */
+    protected $gmworker;
+    /** @var HandlerInterface */
+    protected $handler;
+    /** @var LoggerInterface */
+    protected $logger;
+    /** @var float */
+    protected $timeStop = 0;
+    /** @var int the number of message this worker has processed (is processing) */
+    protected $messageNumber = 0;
+    /** @var int */
+    protected $maxNumMessages = 0;
+    /** @var string */
+    protected $queueName;
+
+    /**
+     * ConsumerCommand constructor.
+     *
+     * @param \GearmanWorker           $gmworker
+     * @param HandlerInterface         $handler
+     * @param LoggerInterface          $logger
+     * @param string                   $queueName       The name of the queue to listen to
+     * @param string                   $name            The name of the command
+     */
+    public function __construct(
+        \GearmanWorker $gmworker,
+        LoggerInterface $logger,
+        HandlerInterface $handler,
+        string $queueName,
+        string $name
+    ) {
+        parent::__construct($name);
+
+        $this->gmworker = $gmworker;
+        $this->logger = $logger;
+        $this->handler = $handler;
+        $this->queueName = $queueName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription('Executes a consumer')
+            ->addOption(
+                static::OPTION_MAX_RUNTIME,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Maximum time in seconds the consumer will run. Must be less than PHP_INT_MAX / 1000. '.
+                    'Pass zero or negative for eternal',
+                0
+            )
+            ->addOption(
+                static::OPTION_MAX_MESSAGES,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Maximum number of messages that should be consumed. Pass zero or negative for no maximum',
+                0
+            )
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (($timeout = $input->getOption(static::OPTION_MAX_RUNTIME)) > 0) {
+            if (PHP_INT_MAX > $timeout * 1000) {
+                // Set the timeout of the gearman connection.
+                $this->timeStop = microtime(true) + $timeout;
+                $this->gmworker->setTimeout((int) ($timeout * 1000));
+            } else {
+                $this->logger->warning('Timeout is too large, no timeout has been configured');
+            }
+        } else {
+            $this->timeStop = 0;
+        }
+
+        $this->maxNumMessages = (int) $input->getOption(static::OPTION_MAX_MESSAGES);
+        $this->messageNumber = 0;
+
+        // Set worker to non-blocking to allow for better end-of-time and max-message handling.
+        $this->gmworker->addOptions(GEARMAN_WORKER_NON_BLOCKING);
+
+        // Add the handle job method
+        $this->gmworker->addFunction($this->queueName, function (\GearmanJob $gearmanJob) {
+            ++$this->messageNumber;
+
+            $this->logger->debug('Start with job', ['message-number' => $this->messageNumber]);
+
+            $success = $this->handleJob($gearmanJob);
+
+            $this->logger->debug('Done with job', ['message-number' => $this->messageNumber]);
+
+            return true; // Always return true; stopping is handled in the loop itself.
+        });
+
+        $this->logger->info('Consumer: Registered worker', [
+            'queue' => $this->queueName,
+            'max-messages' => $this->maxNumMessages,
+            'max-runtime' => $timeout,
+        ]);
+
+        try {
+            while ($this->gmworker->work()
+                || $this->gmworker->returnCode() === GEARMAN_IO_WAIT
+                || $this->gmworker->returnCode() === GEARMAN_NO_JOBS
+            ) {
+                if ($this->gmworker->returnCode() !== GEARMAN_SUCCESS) {
+                    // No job received? Wait for action from server.
+                    $this->gmworker->wait();
+                }
+
+                if ($this->shouldStop()) {
+                    $this->logger->debug('Stopped working');
+                    break;
+                }
+            }
+
+            return 0;
+        } finally {
+            // Always log unregistering. Even if an exception was thrown.
+            $this->logger->info('Consumer: Unregistered worker', ['queue' => $this->queueName]);
+        }
+    }
+
+    /**
+     * Handles $gearmanJob.
+     *
+     * @param \GearmanJob $gearmanJob
+     *
+     * @return bool
+     */
+    protected function handleJob(\GearmanJob $gearmanJob)
+    {
+        gc_enable();
+
+        $taskReturnStatus = call_user_func_array([$this->handler, 'handle'], [$gearmanJob->workload()]);
+
+        // GOTCHA: null means success
+        // TODO: http://stackoverflow.com/questions/5143755/gearman-php-proper-way-for-a-worker-to-send-back-a-failure
+        // TODO: at the moment $taskReturnStatus is true/false, but maybe the response can be returned this way as well
+        (false === $taskReturnStatus) ? $gearmanJob->sendFail() : $gearmanJob->sendComplete($taskReturnStatus);
+
+        gc_collect_cycles();
+        gc_disable();
+
+        return $taskReturnStatus;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function shouldStop()
+    {
+        if (0 < $this->timeStop && microtime(true) > $this->timeStop) {
+            $this->logger->debug('Reached end of time');
+
+            return true;
+        }
+
+        if ($this->maxNumMessages > 0 && $this->messageNumber > $this->maxNumMessages) {
+            $this->logger->debug('Reached maximum number of messages to handle');
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/DependencyInjection/Compiler/AddWorkerHandlerCompilerPass.php
+++ b/DependencyInjection/Compiler/AddWorkerHandlerCompilerPass.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laelaps\GearmanBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+class AddWorkerHandlerCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $abstractConsumerDefinition = $container->getDefinition('laelaps.command.abstract_consumer');
+        $taggedServices = $container->findTaggedServiceIds('laelaps.handler');
+
+        foreach ($taggedServices as $serviceId => $tags) {
+            foreach ($tags as $attributes) {
+
+                if (!isset($attributes['queue_name'])) {
+                    throw new InvalidArgumentException('"queue_name" attribute is required for tag "laelaps.handler"');
+                }
+                $queueName = $attributes['queue_name'];
+                if (substr($queueName, 0, 1) === '%' && substr($queueName, -1, 1) === '%') {
+                    $queueName = $container->getParameter(substr($queueName,1,-1));
+                }
+
+                $newConsumerDefinition = clone $abstractConsumerDefinition;
+                $newConsumerDefinition->setAbstract(false);
+                $newConsumerDefinition->addArgument(new Reference($serviceId));
+                $newConsumerDefinition->addArgument($queueName);
+                $newConsumerDefinition->addArgument(sprintf("gearman:consumer:%s", $queueName));
+                $newConsumerDefinition->addTag('console.command');
+
+                // add definition
+                $definitionId = sprintf("laelaps.command.%s", $queueName);
+                $container->setDefinition($definitionId, $newConsumerDefinition);
+
+                // add definition as a console command
+                $consoleCommands = $container->getParameter('console.command.ids');
+                $consoleCommands[] = $definitionId;
+                $container->setParameter('console.command.ids', $consoleCommands);
+            }
+        }
+    }
+}

--- a/LaelapsGearmanBundle.php
+++ b/LaelapsGearmanBundle.php
@@ -3,8 +3,20 @@
 namespace Laelaps\GearmanBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Laelaps\GearmanBundle\DependencyInjection\Compiler\AddWorkerHandlerCompilerPass;
 
 /**
  * @author Mateusz Charytoniuk <mateusz.charytoniuk@absolvent.pl>
  */
-class LaelapsGearmanBundle extends Bundle {}
+class LaelapsGearmanBundle extends Bundle {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new AddWorkerHandlerCompilerPass());
+    }
+}

--- a/README.md
+++ b/README.md
@@ -129,3 +129,76 @@ $ ./app/console gearman:job:run example_job_name
 ```
 $ ./app/console gearman:job:run example_job_name optional_workload_string
 ```
+
+
+
+### Consumer (alternative implementation for Worker)
+
+As an alternative to the Worker implementation, there is
+a Consumer-Handler implementation.
+
+place jobs on the queue with:
+``` php
+<?php
+$gearman->doBackground('queueName', serialize($workload));
+
+```
+
+write a handler like:
+
+``` php
+<?php
+
+namespace AcmeDemoBundle\Worker;
+
+use Laelaps\GearmanBundle\Worker\HandlerInterface;
+use Psr\Log\LoggerInterface;
+
+class ConsumerHandler implements HandlerInterface
+{
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($message)
+    {
+        try {
+            $workload = unserialize($message);
+            echo $workload;
+        } catch (Exception $e) {
+            $this->logger->error(sprintf("%s: %s", static::class, $e->getMessage()));
+
+            return false;
+        }
+
+        return true;
+    }
+}
+```
+
+And add this class to your service container with a tag:
+
+``` yaml
+    acme.worker.consumer_handler:
+        class: AcmeDemoBundle\Worker\ConsumerHandler
+        arguments:
+            - "@logger"
+        tags:
+            - { name: laelaps.handler, queue_name: 'queueName'}
+```
+
+and run it with:
+
+```
+$ ./app/console gearman:consumer:queueName
+```

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,3 +4,12 @@ services:
     laelaps.gearman.worker:
         class: GearmanWorker
         scope: prototype
+
+    laelaps.command.abstract_consumer:
+        class: Laelaps\GearmanBundle\Command\ConsumerCommand
+        shared: false
+        scope: prototype
+        abstract: true
+        arguments:
+            - "@laelaps.gearman.worker"
+            - "@logger"

--- a/Worker/HandlerInterface.php
+++ b/Worker/HandlerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laelaps\GearmanBundle\Worker;
+
+interface HandlerInterface
+{
+    /**
+     * @param mixed $workload Please note: serialize/unserialize objects when sending/receiving them
+     *
+     * @return bool true on succes
+     */
+    public function handle($workload);
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "laelaps/symfony-gearman-bundle",
-    "description": "Integrates Gearman into Symfony2",
+    "description": "Integrates Gearman into Symfony",
     "keywords": ["symfony", "gearman", "bundle"],
     "homepage": "https://github.com/laelaps/symfony-gearman-bundle",
     "type": "symfony-bundle",
@@ -19,8 +19,8 @@
     "require": {
         "ext-gearman": "*",
         "php": ">=5.3.0",
-        "symfony/console": "~2.1",
-        "symfony/framework-bundle": "~2.1"
+        "symfony/console": ">=2.1",
+        "symfony/framework-bundle": ">=2.1"
     },
     "autoload": {
         "psr-0": { "Laelaps\\GearmanBundle": "" }


### PR DESCRIPTION
This Symfony-gearman implementation was definitely one of the nicer ones I found.

I added an alternative worker, using the service container to tag a handler, creating new CLI-commands with compiler passes. This seems more Symfony to me than using the entry-point implementation. See updated readme for an example.